### PR TITLE
Added shim for drop-in replacing Sass

### DIFF
--- a/lib/sassc/sass_shim.rb
+++ b/lib/sassc/sass_shim.rb
@@ -1,0 +1,12 @@
+require 'sassc'
+
+if defined? ::Sass
+  if ::Sass == ::SassC
+    warn 'warning: Sass already defined. Possible double load issue.'
+  else
+    raise LoadError.new('Sass already defined. Refusing to clobber.')
+  end
+end
+
+::Sass = ::SassC
+$LOAD_PATH.unshift File.expand_path('../sass_shim', __FILE__)

--- a/lib/sassc/sass_shim/sass.rb
+++ b/lib/sassc/sass_shim/sass.rb
@@ -1,0 +1,1 @@
+# This file exists to prevent `require "sass"` from doing anything


### PR DESCRIPTION
This allows you to "effectively" replace Sass with one call:

```
    require 'sassc/sass_shim'
```

This will alias Sass to SassC and any attempts to `require 'sass'` will do nothing.

Calls that uses Sass internal implementation details (e.g. `require 'sass/plugins'`) might not work correctly.
